### PR TITLE
Backport optional caching on all network streams.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -21,6 +21,7 @@
 #include "DVDInputStreamFile.h"
 #include "filesystem/File.h"
 #include "filesystem/IFile.h"
+#include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 
@@ -51,8 +52,15 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
   if (!m_pFile)
     return false;
 
+  unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+
+  if ( g_advancedSettings.m_alwaysForceBuffer && 
+       !URIUtils::IsOnDVD(strFile) && 
+       !URIUtils::IsBluray(strFile) )
+    flags |= READ_CACHED; 
+ 
   // open file in binary mode
-  if (!m_pFile->Open(strFile, READ_TRUNCATED | READ_BITRATE | READ_CHUNKED))
+  if (!m_pFile->Open(strFile, flags))
   {
     delete m_pFile;
     m_pFile = NULL;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -305,6 +305,7 @@ void CAdvancedSettings::Initialize()
 
   m_measureRefreshrate = false;
 
+  m_alwaysForceBuffer = false;
   m_cacheMemBufferSize = 1024 * 1024 * 20;
   // the following setting determines the readRate of a player data
   // as multiply of the default data read rate
@@ -708,6 +709,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+    XMLUtils::GetBoolean(pElement, "alwaysforcebuffer", m_alwaysForceBuffer);
     XMLUtils::GetFloat(pElement, "readbufferfactor", m_readBufferFactor);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -358,6 +358,7 @@ class CAdvancedSettings
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemBufferSize;
+    bool m_alwaysForceBuffer;
     float m_readBufferFactor;
 
     bool m_jsonOutputCompact;


### PR DESCRIPTION
Optionally allow caching for all networks streams, including those on LAN
(via new advanced setting 'alwaysforcebuffer')

As per xbmc commit https://github.com/xbmc/xbmc/commit/018fab22495e5de370b1e6b69e37e93657921f89

As discussed https://github.com/OpenELEC/OpenELEC.tv/pull/2531

Improves cache handling on Raspberry Pi's enourmously.

While I realize this will go ahead when gotham gets pulled down, the quality of life these changes make for Raspberry Pi, I'd greatly appreciate if these patches could be added meanwhile.
