### PR TITLE
Native Resolution

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -43,6 +43,7 @@ CBaseRenderer::CBaseRenderer()
   m_oldRenderOrientation = 0;
   m_oldDestRect.SetRect(0.0f, 0.0f, 0.0f, 0.0f);
   m_iFlags = 0;
+  m_bestResolution = m_resolution; 
 
   for(int i=0; i < 4; i++)
   {
@@ -83,6 +84,68 @@ void CBaseRenderer::ChooseBestResolution(float fps)
 
     CLog::Log(LOGNOTICE, "Display resolution ADJUST : %s (%d) (weight: %.3f)",
         g_settings.m_ResInfo[m_resolution].strMode.c_str(), m_resolution, weight);
+        
+	  m_bestResolution = m_resolution;                                   // save it
+	  int iNatW = (int)m_sourceWidth;
+	  int iNatH = (int)m_sourceHeight;
+
+	  if( g_advancedSettings.m_nativeMaxWidth && iNatW > g_advancedSettings.m_nativeMaxWidth )
+		iNatW = 0;
+
+	  if( g_advancedSettings.m_nativeMaxHeight && iNatH > g_advancedSettings.m_nativeMaxHeight )
+		iNatH = 0;
+
+	  if( g_advancedSettings.m_nativeUpscaleMode && iNatW && iNatH )     // Native Upscale Mode
+	  { 
+		CLog::Log(LOGNOTICE, "Searching for NATIVE resolution: %dx%d", m_sourceWidth, m_sourceHeight);
+		
+		bool bOverrideFPS = g_advancedSettings.m_nativeOverrideFPS;
+		double nfRD, fRD, fD, fODist = 100000000.0;
+		int iWD, iHD;
+		double fOrgRefreshRate = g_settings.m_ResInfo[m_resolution].fRefreshRate;
+		int iOrgScreen = g_settings.m_ResInfo[m_resolution].iScreen;
+
+		if(iNatW <= g_advancedSettings.m_nativeMinWidth && 
+		   iNatH <= g_advancedSettings.m_nativeMinHeight)
+		{
+		  iNatW = g_advancedSettings.m_nativeMinWidth;
+		  iNatH = g_advancedSettings.m_nativeMinHeight;
+		}
+		
+		// best fit
+		for (size_t i = (int)RES_DESKTOP; i < g_settings.m_ResInfo.size(); i++)  
+		{
+		  fRD = g_settings.m_ResInfo[i].fRefreshRate - fOrgRefreshRate;  // refreshrate delta
+		  nfRD = g_settings.m_ResInfo[i].fRefreshRate / fOrgRefreshRate; // refreshrate fit
+		  iWD = g_settings.m_ResInfo[i].iWidth - iNatW;                  // width delta 
+		  iHD = g_settings.m_ResInfo[i].iHeight - iNatH;                 // height delta
+		  // distance function:
+		  // refreshrate, witdh and height deltas are multiplied by weight factors
+		  // current weights values do not prefer any parameter (well, almost...)
+		  // so we will search for lowest width, height and refresh rate which fit to the source parameters
+		  // however if any of these parameters need to be preferred, bump up the weight value for it
+		  fD = (iWD * 1.0) + (iHD * 1.0);                                // default weights for width and height resolution
+	 
+		  if (!bOverrideFPS)
+		  {                                                              // if original fps should be preserved, accept only these 
+			fRD = (fRD == 0.0) ? (0.0) : (-1.0);                         // resolutions where refreshrate is the same
+		  }
+		  else
+		  {                                                              // preferred multiple fps     
+			fD += fRD + ( (abs(nfRD-floor(nfRD+0.5)) < 1e-6) ? 10.0 : 1000.0 );
+		  }
+		 
+		  if( fRD >= 0.0 && iWD >= 0 && iHD >= 0 && fD <= fODist &&
+			  g_settings.m_ResInfo[i].iScreen == iOrgScreen ) 
+		  {
+			m_resolution = (RESOLUTION)i;         // if we are here, then this resolution is closer to 
+			fODist = fD;                          // the source parameters than previous one
+		  }
+		}
+
+		CLog::Log(LOGNOTICE, "Display resolution ADJUST2 : %s (%d)",
+			g_settings.m_ResInfo[m_resolution].strMode.c_str(), m_resolution);
+	  }
   }
   else
 #endif
@@ -575,13 +638,15 @@ void CBaseRenderer::ManageDisplay()
 
 void CBaseRenderer::SetViewMode(int viewMode)
 {
+  int savedViewMode; 
+  
   if (viewMode < VIEW_MODE_NORMAL || viewMode > VIEW_MODE_CUSTOM)
     viewMode = VIEW_MODE_NORMAL;
 
   if (m_iFlags & (CONF_FLAGS_FORMAT_SBS | CONF_FLAGS_FORMAT_TB))
     viewMode = VIEW_MODE_NORMAL;
 
-  g_settings.m_currentVideoSettings.m_ViewMode = viewMode;
+  g_settings.m_currentVideoSettings.m_ViewMode = savedViewMode = viewMode;
 
   // get our calibrated full screen resolution
   RESOLUTION res = GetResolution();
@@ -594,6 +659,27 @@ void CBaseRenderer::SetViewMode(int viewMode)
     screenHeight /= 2;
   // and the source frame ratio
   float sourceFrameRatio = GetAspectRatio();
+  
+  // if we upscale via external AVR device, correct the pixel ratio
+  if( g_advancedSettings.m_nativeUpscaleMode && m_bestResolution != m_resolution  
+   && g_advancedSettings.m_nativeCorrectPixelRatio ) 
+  {
+    float destWidth = (float)(g_advancedSettings.m_nativeDestWidth);
+    float destHeight = (float)(g_advancedSettings.m_nativeDestHeight);
+    float destFrameRatio = (float)destWidth / destHeight;
+    bool  destScreenIs43 = (destFrameRatio < 8.f/(3.f*sqrt(3.f)));   // final output
+    float outWidth = (float)(g_settings.m_ResInfo[m_resolution].iWidth);
+    float outHeight = (float)(g_settings.m_ResInfo[m_resolution].iHeight);
+    float outFrameRatio = (float)outWidth / outHeight;
+    bool  outScreenIs43 = (outFrameRatio < 8.f/(3.f*sqrt(3.f)));     // xbmc output
+
+    if( outScreenIs43 && !destScreenIs43 )         // final output is 16x9
+      viewMode = VIEW_MODE_STRETCH_16x9;
+    else if( !outScreenIs43 && destScreenIs43 )    // final output is 4x3
+      viewMode = VIEW_MODE_STRETCH_4x3;
+
+    g_settings.m_currentVideoSettings.m_ViewMode = viewMode;
+  }
 
   bool is43 = (sourceFrameRatio < 8.f/(3.f*sqrt(3.f)) &&
               g_settings.m_currentVideoSettings.m_ViewMode == VIEW_MODE_NORMAL);
@@ -692,7 +778,10 @@ void CBaseRenderer::SetViewMode(int viewMode)
     g_settings.m_fPixelRatio = 1.0;
     g_settings.m_fZoomAmount = 1.0;
   }
-
+  
+  // restore original view mode
+  g_settings.m_currentVideoSettings.m_ViewMode = savedViewMode;
+  
   g_settings.m_currentVideoSettings.m_CustomZoomAmount = g_settings.m_fZoomAmount;
   g_settings.m_currentVideoSettings.m_CustomPixelRatio = g_settings.m_fPixelRatio;
   g_settings.m_currentVideoSettings.m_CustomNonLinStretch = g_settings.m_bNonLinStretch;

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -113,6 +113,7 @@ protected:
   void       MarkDirty();
 
   RESOLUTION m_resolution;    // the resolution we're running in
+  RESOLUTION m_bestResolution;  // the preferred resolution 
   unsigned int m_sourceWidth;
   unsigned int m_sourceHeight;
   float m_sourceFrameRatio;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -118,6 +118,16 @@ void CAdvancedSettings::Initialize()
   m_videoBusyDialogDelay_ms = 100;
   m_videoDefaultLatency = 0.0;
   m_videoDisableHi10pMultithreading = false;
+  
+  m_nativeUpscaleMode = false;
+  m_nativeOverrideFPS = true;
+  m_nativeCorrectPixelRatio = true;
+  m_nativeDestWidth = 1920;
+  m_nativeDestHeight = 1080;
+  m_nativeMinWidth = 0;
+  m_nativeMinHeight = 0;
+  m_nativeMaxWidth = 1024;
+  m_nativeMaxHeight = 768;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -515,6 +525,50 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);
     XMLUtils::GetBoolean(pElement,"vdpauHDdeintSkipChroma",m_videoVDPAUdeintSkipChromaHD);
 
+    TiXmlElement* pNativeUpscale = pElement->FirstChildElement("nativeupscale");
+    if (pNativeUpscale)
+    {
+      m_nativeUpscaleMode = true;
+
+      XMLUtils::GetBoolean(pNativeUpscale, "overridefps", m_nativeOverrideFPS);
+      XMLUtils::GetBoolean(pNativeUpscale, "correctpixelratio", m_nativeCorrectPixelRatio);
+
+      CStdString tmpStr;
+
+      if (XMLUtils::GetString(pNativeUpscale, "destres",tmpStr))
+      {
+        int destWidth, destHeight;
+
+        if( sscanf(tmpStr.c_str(), "%dx%d", &destWidth, &destHeight) == 2 )
+        { 
+          m_nativeDestWidth = destWidth;
+          m_nativeDestHeight = destHeight;
+        }
+      }
+
+      if (XMLUtils::GetString(pNativeUpscale, "minoutres",tmpStr))
+      {
+        int minWidth, minHeight;
+
+        if( sscanf(tmpStr.c_str(), "%dx%d", &minWidth, &minHeight) == 2 )
+        {
+          m_nativeMinWidth = minWidth;
+          m_nativeMinHeight = minHeight;
+        }
+      }
+
+      if (XMLUtils::GetString(pNativeUpscale, "maxsrcres",tmpStr))
+      {
+        int maxWidth, maxHeight;
+      
+        if( sscanf(tmpStr.c_str(), "%dx%d", &maxWidth, &maxHeight) == 2 )
+        {
+          m_nativeMaxWidth = maxWidth;
+          m_nativeMaxHeight = maxHeight;
+        }
+      }
+    }
+	
     TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)
     {

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -171,6 +171,16 @@ class CAdvancedSettings
     bool m_videoDisableHi10pMultithreading;
     int  m_videoBusyDialogDelay_ms;
 
+	bool m_nativeUpscaleMode;
+    bool m_nativeOverrideFPS;
+    bool m_nativeCorrectPixelRatio;
+    int  m_nativeDestWidth;
+    int  m_nativeDestHeight;
+    int  m_nativeMinWidth;
+    int  m_nativeMinHeight;
+    int  m_nativeMaxWidth;
+    int  m_nativeMaxHeight;
+	
     CStdString m_videoDefaultPlayer;
     CStdString m_videoDefaultDVDPlayer;
     float m_videoPlayCountMinimumPercent;


### PR DESCRIPTION
<b>adam-aph code (xbmc pull 1096) updated to Frodo</b>
Native resolution should be used only if no up-/downscaling is made by XBMC.

&lt;video&gt;
...
&lt;nativeupscale&gt;
&lt;overridefps&gt;true&lt;/overridefps&gt;
&lt;correctpixelratio&gt;true&lt;/correctpixelratio&gt;
&lt;destres&gt;1920x1080&lt;/destres&gt;
&lt;minoutres&gt;0x0&lt;/minoutres&gt;
&lt;maxsrcres&gt;0x0&lt;/maxsrcres&gt;
&lt;/nativeupscale&gt;
...
&lt;/video&gt;

where:
&lt;overridefps&gt;        - controls if the fps can be overridden or not (default is 'true')
&lt;correctpixelratio&gt;  - controls if the output should be stretched to final screen dimensions (default is 'true')
&lt;destres&gt;            - controls the destination resolution (width x height), to which the source will be scaled by AVR (default is '1920x1080')
&lt;minoutres&gt;         - controls the minimum acceptable output resolution (width x height), which will be generated by xbmc (default is '0x0' - not active)
&lt;maxsrcres&gt;         - controls the maximum source resolution (width x height), which will be handled by native scaling (default is '1024x768', '0x0' disables this check)
