### PR TITLE
Add a GUI message to let windows handle suspend/wakeup events to close their network/mysql connections

### DIFF
--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -132,6 +132,13 @@
 
 #define GUI_MSG_SET_TEXT        42
 
+/*!
+ \brief Signal a window that the system is going to suspend or has just woke up
+ */
+#define GUI_MSG_SLEEP         43
+
+#define GUI_MSG_WAKE          44
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -989,3 +989,19 @@ void CGUIWindowManager::DumpTextureUse()
   }
 }
 #endif
+
+void CGUIWindowManager::OnSleep()
+{
+    CLog::Log(LOGNOTICE, "%s: Going to sleep up", __FUNCTION__);
+
+    CGUIMessage msg(GUI_MSG_SLEEP, 0, 0);
+    this->SendMessage(msg);
+}
+
+void CGUIWindowManager::OnWake()
+{
+    CLog::Log(LOGNOTICE, "%s: Woke up", __FUNCTION__);
+
+    CGUIMessage msg(GUI_MSG_WAKE, 0, 0);
+    this->SendMessage(msg);
+}

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -130,6 +130,9 @@ public:
 #ifdef _DEBUG
   void DumpTextureUse();
 #endif
+  void OnSleep();
+  void OnWake();
+
 private:
   void RenderPass();
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -235,6 +235,12 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
         }
       }
     }
+  case GUI_MSG_SLEEP:
+    m_musicdatabase.Close();
+    break;
+  case GUI_MSG_WAKE:
+    m_musicdatabase.Open();
+    break;
   }
   return CGUIMediaWindow::OnMessage(message);
 }

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -32,6 +32,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GraphicContext.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "guilib/GUIWindowManager.h"
 
 #ifdef HAS_LCD
 #include "utils/LCDFactory.h"
@@ -201,11 +202,15 @@ void CPowerManager::OnSleep()
   g_application.StopPlaying();
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();
+
+  g_windowManager.OnSleep();
 }
 
 void CPowerManager::OnWake()
 {
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
+
+  g_windowManager.OnWake();
 
   // reset out timers
   g_application.ResetShutdownTimers();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -225,6 +225,12 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
   case GUI_MSG_SEARCH:
     OnSearch();
     break;
+  case GUI_MSG_SLEEP:
+    m_database.Close();
+    break;
+  case GUI_MSG_WAKE:
+    m_database.Open();
+    break;
   }
   return CGUIMediaWindow::OnMessage(message);
 }


### PR DESCRIPTION
A window having an open MySQL-connection when going to suspend will make XBMC freeze after wake up when the MySQL connection timed out in the meantime. (Observed and debugged on OpenELEC 3.1.7).
